### PR TITLE
feat(vectortile): Add field "desc" for otp-stop vector tile features

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ const stopQuery = `
       lat
       lon
       locationType
+      desc
       parentStation {
         gtfsId
       }
@@ -93,6 +94,7 @@ const stopMapper = data => ({
       name: stop.name,
       code: stop.code,
       platform: stop.platformCode,
+      desc: stop.desc,
       parentStation: stop.parentStation == null ? null : stop.parentStation.gtfsId,
       type: stop.patterns == null ? null : stop.patterns.map(pattern => pattern.route.mode).uniq().join(","),
       patterns: stop.patterns == null ? null : JSON.stringify(stop.patterns.map(pattern => ({


### PR DESCRIPTION
Add field "desc" to stops for OTP graphql query and the resulting geojson served as vector tile.
New digitransit-ui requires the description field for each stop.